### PR TITLE
Fix: #17, #30

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -66,9 +66,6 @@ export default {
     this.isMounted = true
   },
   computed: {
-    canvasWidth() {
-      return this.isMounted ? this.$refs.app.clientWidth : undefined
-    },
     points() {
       return this.isMounted
         ? [this.$refs.img1.points, this.$refs.img2.points]

--- a/frontend/src/components/canvas/Point.vue
+++ b/frontend/src/components/canvas/Point.vue
@@ -49,6 +49,9 @@ export default {
     }
   },
   computed: {
+    text() {
+      return `${this.$vnode.key}`
+    },
     scaledCircleConfig() {
       const scale = this.scale || 1.0
       const base = this.baseConfig.circle
@@ -65,7 +68,7 @@ export default {
 
       return {
         fontSize: base.fontSize * scale,
-        x: -(scaledRadius * 0.4),
+        x: -(scaledRadius * this.text.length * 0.4),
         y: -(scaledRadius * 0.5),
       }
     },
@@ -87,7 +90,7 @@ export default {
     },
     textConfig() {
       return {
-        text: `${this.$vnode.key}`,
+        text: this.text,
         fill: this.color.fg,
         ...this.scaledTextConfig,
       }

--- a/frontend/src/components/canvas/ScalableStage.vue
+++ b/frontend/src/components/canvas/ScalableStage.vue
@@ -39,6 +39,12 @@ export default {
   mounted() {
     this.isMounted = true
     this.$emit("scaling", this.stageScale)
+    window.addEventListener("resize", () => {
+      this.konva.stage.size({
+        width: this.$parent.$el.clientWidth,
+        height: this.$parent.$el.clientHeight,
+      })
+    })
   },
   computed: {
     stage() {


### PR DESCRIPTION
## 対応一覧

### #17 に対処
- `ScalableStage.vue` に、`resize` イベントのリスナーを追加
  - 親の要素の `clientWidth` と `clientHeight` を再取得し、Stage をリサイズする

### #30 に対処
- 数字の桁数に応じて、テキストのオフセットを変更